### PR TITLE
replace all PMS with PYM

### DIFF
--- a/Self-writtenCode/彭一鸣ParadoxGUI/countrypoliticsview.gui
+++ b/Self-writtenCode/彭一鸣ParadoxGUI/countrypoliticsview.gui
@@ -1058,10 +1058,10 @@ guiTypes = {
 
             #TSRchange TSR修改
 			containerWindowType = {
-				name = "PMS_scr_government_window_cover"	
+				name = "PYM_scr_government_window_cover"	
 				position = { x = 30 y = 30 }
 				containerWindowType = {
-					name = "PMS_scr_government_window_anchor"	
+					name = "PYM_scr_government_window_anchor"	
 					position = { x = 0 y = 0 }
 				}
 				iconType ={
@@ -2313,7 +2313,7 @@ guiTypes = {
 	
 	## TSR GUI below ##
 	containerWindowType = {
-		name = "PMS_scr_collapse_btn_window"	
+		name = "PYM_scr_collapse_btn_window"	
 		position = { x = 0 y = 0 }
 		iconType ={
 			name ="category_header"
@@ -2325,7 +2325,7 @@ guiTypes = {
 			name = "name"
 			position = { x = 460 y = 8 }
 			font = "VCR02_18"
-			text = "PMS_scr_collapse_btn_name" # "查看所有官员列表"
+			text = "PYM_scr_collapse_btn_name" # "查看所有官员列表"
 			maxWidth = 300
 			maxHeight = 20
 		}
@@ -2339,7 +2339,7 @@ guiTypes = {
 		
 	}
 	containerWindowType = {
-		name = "PMS_scr_government_window"	
+		name = "PYM_scr_government_window"	
 		position = { x = 0 y = 0 }
 		show_position = { x = 0 y = 20 }
 		show_animation_type = decelerated
@@ -2355,13 +2355,13 @@ guiTypes = {
 
 		buttonType = {
 			position = { x = 75 y = 16}
-			name = "PMS_show_cabinet_window_button"
+			name = "PYM_show_cabinet_window_button"
 			quadTextureSprite = "GFX_idea_laws_trade4"
 			
 		}
 		buttonType = {
 			position = { x = 315 y = 16}
-			name = "PMS_show_secretariat_window_button"
+			name = "PYM_show_secretariat_window_button"
 			quadTextureSprite = "GFX_idea_laws_trade4"
 			
 		}
@@ -2369,7 +2369,7 @@ guiTypes = {
 	}
 
 	containerWindowType = {
-		name = "PMS_cabinet_window"	
+		name = "PYM_cabinet_window"	
 		position = { x = -350 y = 0 }
 		show_position = { x = 720 y = 0 }
 		show_animation_type = decelerated
@@ -2387,7 +2387,7 @@ guiTypes = {
 			name = "title"
 			position = { x = 25 y = 7 }
 			font = "VCR02_20"
-			text = "PMS_cabinet_ministers" #"国务大臣"
+			text = "PYM_cabinet_ministers" #"国务大臣"
 			maxWidth = 450
 			maxHeight = 20
 			format = center
@@ -2396,7 +2396,7 @@ guiTypes = {
 			name = "switch"
 			position = { x = 25 y = 30 }
 			font = "VCR02_12"
-			text = "PMS_cabinet_cabinet" #"少女内阁"
+			text = "PYM_cabinet_cabinet" #"少女内阁"
 			maxWidth = 450
 			maxHeight = 20
 			format = center
@@ -2426,7 +2426,7 @@ guiTypes = {
 				}
 	
 				gridBoxType = {
-					name = "PMS_lists_of_ministers"
+					name = "PYM_lists_of_ministers"
 					position = { x = 15 y = 0}
 					size = { width = 100%% height = 100%% }
 					Orientation = upper_left
@@ -2448,7 +2448,7 @@ guiTypes = {
 		}
 	}
 	containerWindowType = {
-		name = "PMS_list_of_ministers_entry"
+		name = "PYM_list_of_ministers_entry"
 		size = { width = 502 height = 74 }
 		position = { x = 0 y = 0 }
 		clipping = no
@@ -2460,19 +2460,19 @@ guiTypes = {
 		}
 		
 		iconType = {
-			name = "PMS_ministry_icon"
+			name = "PYM_ministry_icon"
 			position = { x = 7 y = 4 }
 			spriteType = ""
 			alwaystransparent = yes
 		}
 		iconType = {
-			name = "PMS_ministry_background"
+			name = "PYM_ministry_background"
 			position = { x = 7 y = 4 }
 			spriteType = ""
 			alwaystransparent = yes
 		}
 		iconType = {
-			name = "PMS_minister_icon"
+			name = "PYM_minister_icon"
 			position = { x = 7 y = 4 }
 			spriteType = ""
 			alwaystransparent = yes
@@ -2481,7 +2481,7 @@ guiTypes = {
 	
 	
 	containerWindowType = {
-		name = "PMS_secretariat_window"
+		name = "PYM_secretariat_window"
 		position = { x = -350 y = 0 }	
 		show_position = { x = 720 y = 0 }
 		show_animation_type = decelerated
@@ -2539,7 +2539,7 @@ guiTypes = {
 	
 				
 				containerWindowType = {
-					name = "PMS_Prime_Minister_entry"
+					name = "PYM_Prime_Minister_entry"
 					size = { width = 462 height = 74 }
 					position = { x = 15 y = 0 }
 					clipping = no
@@ -2551,7 +2551,7 @@ guiTypes = {
 					}
 						
 					iconType = {
-						name = "PMS_Prime_Minister_icon"
+						name = "PYM_Prime_Minister_icon"
 						position = { x = 42 y = 38 }
 						spriteType = "GFX_placeholder_bordered"
 						centerposition = yes
@@ -2565,7 +2565,7 @@ guiTypes = {
 						size = { width=170 height=100%% }
 						
 						instantTextboxType = {
-							name = "PMS_Prime_Minister_title"
+							name = "PYM_Prime_Minister_title"
 							position = { x = 0 y = -13 }
 							font = "VCR02_12"
 							fixedsize = yes			
@@ -2579,7 +2579,7 @@ guiTypes = {
 					}
 					
 					instantTextboxType = {
-						name = "PMS_Prime_Minister_name"
+						name = "PYM_Prime_Minister_name"
 						position = { x = 200 y = 32 }
 						font = "VCR02_12"
 						text = "现任：丰川祥子"
@@ -2590,7 +2590,7 @@ guiTypes = {
 					}
 				}
 				containerWindowType = {
-					name = "PMS_Chief_Cabinet_Secretary_entry"
+					name = "PYM_Chief_Cabinet_Secretary_entry"
 					size = { width = 462 height = 74 }
 					position = { x = 15 y = 75 }
 					clipping = no
@@ -2602,7 +2602,7 @@ guiTypes = {
 					}
 						
 					iconType = {
-						name = "PMS_Prime_Minister_icon"
+						name = "PYM_Prime_Minister_icon"
 						position = { x = 42 y = 38 }
 						spriteType = "GFX_placeholder_bordered"
 						centerposition = yes
@@ -2616,7 +2616,7 @@ guiTypes = {
 						size = { width=170 height=100%% }
 						
 						instantTextboxType = {
-							name = "PMS_Chief_Cabinet_Secretary_title"
+							name = "PYM_Chief_Cabinet_Secretary_title"
 							position = { x = 0 y = -13 }
 							font = "VCR02_12"
 							fixedsize = yes			
@@ -2630,7 +2630,7 @@ guiTypes = {
 					}
 					
 					instantTextboxType = {
-						name = "PMS_Chief_Cabinet_Secretary_name"
+						name = "PYM_Chief_Cabinet_Secretary_name"
 						position = { x = 200 y = 32 }
 						font = "VCR02_12"
 						text = "现任：三角初华"


### PR DESCRIPTION
**类型**：
- [ √] Bug修复
- [ ] 新功能
- [ ] 文档更新
- [ ] 重构/优化

**解决的问题**：
- 在使用 countrypoliticsview.gui 文件时，发现其中的占位符 PMS 已被占用，导致文件无法正确读取。为解决此问题，决定将 PMS 全部替换为 PYM。

**变更内容**（必填）：
- 具体修改的文件/模块：countrypoliticsview.gui 文件
- 核心逻辑变更说明：在 countrypoliticsview.gui 文件中，使用全局替换功能将所有的 PMS 替换为 PYM。这样可以避免因 PMS 被占用而导致的读取错误。

**测试验证**：
- [ ] 已添加单元测试
- [ √] 手动测试步骤：
打开修改后的 countrypoliticsview.gui 文件，检查是否所有的 PMS 都已被替换为 PYM。
运行相关程序，验证文件是否能够正常读取，且功能是否正常。经过测试，文件能够正常读取，且相关功能未受影响。

**其他说明**：
- 需要特别注意的兼容性变更本次修改仅涉及 countrypoliticsview.gui 文件中的占位符替换，预期不会对其他部分产生兼容性问题。但建议在集成到整体项目时，进行全面的测试。
